### PR TITLE
Refresh group information from brokers concurrently

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -20,6 +21,8 @@ var (
 	refreshInt     = flag.Int("refresh-interval", 15, "Time between offset refreshes in seconds.")
 	debug          = flag.Bool("debug", false, "Enable debug output.")
 )
+
+type TopicSet map[string]map[int32]int64
 
 func init() {
 	if err := envflag.Parse(); err != nil {
@@ -37,12 +40,15 @@ func main() {
 		config.ClientID = "kafka-offset-lag-for-prometheus"
 		config.Version = sarama.V0_9_0_0
 		client, err := sarama.NewClient(strings.Split(*kafkaBrokers, ","), config)
+
 		if err != nil {
 			log.Fatal("Unable to connect to given brokers.")
 		}
+
 		defer client.Close()
+
 		for {
-			topicSet := make(map[string]map[int32]int64)
+			topicSet := make(TopicSet)
 			time.Sleep(time.Duration(*refreshInt) * time.Second)
 			timer := prometheus.NewTimer(LookupHist)
 			client.RefreshMetadata()
@@ -52,6 +58,7 @@ func main() {
 				log.Printf("Error fetching topics: %s", err.Error())
 				continue
 			}
+
 			for _, topic := range topics {
 				// Don't include internal topics
 				if strings.HasPrefix(topic, "__") {
@@ -75,6 +82,7 @@ func main() {
 					topicSet[topic][partition] = toff
 				}
 			}
+
 			// Prometheus SDK never TTLs out data points so tmp consumers last
 			// forever. Ugly hack to clean up data points from time to time.
 			if cycle >= 99 {
@@ -82,6 +90,9 @@ func main() {
 				cycle = 0
 			}
 			cycle++
+
+			var wg sync.WaitGroup
+
 			// Now lookup our group data using the metadata
 			for _, broker := range client.Brokers() {
 				// Sarama plays russian roulette with the brokers
@@ -91,46 +102,66 @@ func main() {
 					log.Printf("Could not speak to broker %s. Your advertised.listeners may be incorrect.", broker.Addr())
 					continue
 				}
-				grequest := new(sarama.ListGroupsRequest)
-				gresponse, err := broker.ListGroups(grequest)
-				if err != nil {
-					log.Printf("Could not list groups: %s\n", err.Error())
-					continue
-				}
-				for group, t := range gresponse.Groups {
-					// we only want active consumers
-					if t == "consumer" {
-						// This is not very efficient but the kafka API sucks
-						for topic, data := range topicSet {
-							ofrequest := new(sarama.OffsetFetchRequest)
-							ofrequest.Version = 1
-							ofrequest.ConsumerGroup = group
-							for partition := range data {
-								ofrequest.AddPartition(topic, partition)
-							}
-							oresponse, err := broker.FetchOffset(ofrequest)
-							if err != nil {
-								log.Printf("Could not get offset: %s\n", err.Error())
-							}
-							for _, ofrb := range oresponse.Blocks {
-								for gp, block := range ofrb {
-									if *debug {
-										log.Printf("Discovered group: %s, topic: %s, partition: %d, offset: %d\n", group, topic, gp, block.Offset)
-									}
-									// Offset will be -1 if the group isn't active on the topic
-									if block.Offset >= 0 {
-										// Because our offset operations aren't atomic we could end up with a negative lag
-										lag := math.Max(float64(data[gp]-block.Offset), 0)
-										OffsetLag.With(prometheus.Labels{"topic": topic, "group": group, "partition": strconv.FormatInt(int64(gp), 10)}).Set(lag)
-									}
-								}
-							}
-						}
-					}
-				}
+
+				wg.Add(1)
+
+				go func(broker *sarama.Broker) {
+					defer wg.Done()
+					refreshBroker(broker, topicSet)
+				}(broker)
 			}
+
+			wg.Wait()
 			timer.ObserveDuration()
 		}
 	}()
 	prometheusListen(*prometheusAddr)
+}
+
+func refreshBroker(broker *sarama.Broker, topicSet TopicSet) {
+	groupsRequest := new(sarama.ListGroupsRequest)
+	groupsResponse, err := broker.ListGroups(groupsRequest)
+
+	if err != nil {
+		log.Printf("Could not list groups: %s\n", err.Error())
+		return
+	}
+
+	for group, t := range groupsResponse.Groups {
+		// we only want active consumers
+		if t == "consumer" {
+			// This is not very efficient but the kafka API sucks
+			for topic, data := range topicSet {
+				offsetsRequest := new(sarama.OffsetFetchRequest)
+				offsetsRequest.Version = 1
+				offsetsRequest.ConsumerGroup = group
+				for partition := range data {
+					offsetsRequest.AddPartition(topic, partition)
+				}
+
+				offsetsResponse, err := broker.FetchOffset(offsetsRequest)
+				if err != nil {
+					log.Printf("Could not get offset: %s\n", err.Error())
+				}
+
+				for _, blocks := range offsetsResponse.Blocks {
+					for partition, block := range blocks {
+						if *debug {
+							log.Printf("Discovered group: %s, topic: %s, partition: %d, offset: %d\n", group, topic, partition, block.Offset)
+						}
+						// Offset will be -1 if the group isn't active on the topic
+						if block.Offset >= 0 {
+							// Because our offset operations aren't atomic we could end up with a negative lag
+							lag := math.Max(float64(data[partition]-block.Offset), 0)
+
+							OffsetLag.With(prometheus.Labels{
+								"topic": topic, "group": group,
+								"partition": strconv.FormatInt(int64(partition), 10),
+							}).Set(lag)
+						}
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
I have quite a few brokers that I'm tracking. This PR runs through the broker refresh loop concurrently with a goroutine and a WaitGroup, cutting the time down dramatically.