### PR TITLE
Expand lookup duration buckets to span minutes

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -24,8 +24,9 @@ var (
 	// LookupHist is a Prometheus histogram of our kafka offset lookup time
 	LookupHist = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name: "kafka_consumer_group_lag_lookup_duration_seconds",
-			Help: "Histogram for the runtime of the offset request.",
+			Name:    "kafka_consumer_group_lag_lookup_duration_seconds",
+			Help:    "Histogram for the runtime of the offset request.",
+			Buckets: prometheus.LinearBuckets(60, 60, 5),
 		},
 	)
 )


### PR DESCRIPTION
`kafka_consumer_group_lag_lookup_duration` should span whole seconds, not fractions of seconds