### PR TITLE
Add support to install with helm

### DIFF
--- a/charts/kafka-offset-lag-for-prometheus/Chart.yaml
+++ b/charts/kafka-offset-lag-for-prometheus/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.5"
+description: Expose Kafka consumer offset lag to prometheus.
+name: kafka-offset-lag-for-prometheus
+version: 1.5.0

--- a/charts/kafka-offset-lag-for-prometheus/templates/_helpers.tpl
+++ b/charts/kafka-offset-lag-for-prometheus/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka-offset-lag-for-prometheus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kafka-offset-lag-for-prometheus.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka-offset-lag-for-prometheus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kafka-offset-lag-for-prometheus.labels" -}}
+app.kubernetes.io/name: {{ include "kafka-offset-lag-for-prometheus.name" . }}
+helm.sh/chart: {{ include "kafka-offset-lag-for-prometheus.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/kafka-offset-lag-for-prometheus/templates/deployment.yaml
+++ b/charts/kafka-offset-lag-for-prometheus/templates/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kafka-offset-lag-for-prometheus.fullname" . }}
+  labels:
+{{ include "kafka-offset-lag-for-prometheus.labels" .  | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+{{ include "kafka-offset-lag-for-prometheus.labels" .  | indent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image }}"
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          env:
+          - name: SASL_USER
+            value: {{ .Release.Name }}
+          - name: SASL_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}
+                key: password
+          command:
+          - /go/bin/kafka-offset-lag-for-prometheus
+          - --prometheus-addr=:{{ .Values.metricsPort }}
+          - --refresh-interval={{ .Values.refreshIntervalSeconds }}
+      {{- range $key, $value := .Values.containerArgs }}
+          {{- if $value }}
+          - --{{ $key }}={{ $value }}
+          {{- else }}
+          - --{{ $key }}
+          {{- end }}
+      {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metricsPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: {{ .Values.metricsPort }}
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: {{ .Values.metricsPort }}

--- a/charts/kafka-offset-lag-for-prometheus/templates/kafkauser.yaml
+++ b/charts/kafka-offset-lag-for-prometheus/templates/kafkauser.yaml
@@ -1,0 +1,28 @@
+{{ if .Values.createKafkaUser }}
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  labels:
+    strimzi.io/cluster: {{ .Values.kafkaCluster }}
+{{ include "kafka-offset-lag-for-prometheus.labels" .  | indent 4 }}
+  name: {{ .Release.Name }}
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+    - operation: Describe
+      resource:
+        type: cluster
+    - operation: Describe
+      resource:
+        name: "*"
+        type: group
+        patternType: literal
+    - operation: Describe
+      resource:
+        name: "*"
+        type: topic
+        patternType: literal
+{{ end }}

--- a/charts/kafka-offset-lag-for-prometheus/templates/networkpolicy.yaml
+++ b/charts/kafka-offset-lag-for-prometheus/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.createNetworkPolicy }}
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+{{ include "kafka-offset-lag-for-prometheus.labels" .  | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+  - Ingress
+  ingress:
+{{ toYaml .Values.ingressFromRule | indent 2 }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.metricsPort }}
+{{ end }}

--- a/charts/kafka-offset-lag-for-prometheus/templates/service.yaml
+++ b/charts/kafka-offset-lag-for-prometheus/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-metrics
+  labels:
+{{ include "kafka-offset-lag-for-prometheus.labels" .  | indent 4 }}
+spec:
+  ports:
+  - port: {{ .Values.metricsPort }}
+    name: metrics
+  clusterIP: None
+  selector:
+    app: {{ .Release.Name }}

--- a/charts/kafka-offset-lag-for-prometheus/templates/servicemonitor.yaml
+++ b/charts/kafka-offset-lag-for-prometheus/templates/servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+{{ include "kafka-offset-lag-for-prometheus.labels" . | indent 4}}
+spec:
+  endpoints:
+  - interval: {{ .Values.refreshIntervalSeconds }}s
+    port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/kafka-offset-lag-for-prometheus/values.yaml
+++ b/charts/kafka-offset-lag-for-prometheus/values.yaml
@@ -1,0 +1,41 @@
+#nameOverride -- Overrides release name, prepended by "kafka-offset-lag-for-prometheus"
+nameOverride: ""
+#fullnameOverride -- Overrides release name
+fullnameOverride: ""
+
+#replicaCount -- Kubernetes replica count
+replicaCount: 1
+
+#image -- Docker container image
+image: pceric/kafka-offset-lag-for-prometheus:v1.5@sha256:4f3b7cbf107ca5203bf918628f42c1cfbb553fbdbc9c01601e8a39a2054b4af9
+#pullPolicy -- Docker container image pull policy
+pullPolicy: IfNotPresent
+
+#metricsPort -- The port to use for prometheus metrics endpoint
+metricsPort: 7979
+
+#refreshIntervalSeconds -- The refresh interval used to fetch metrics (in seconds)
+refreshIntervalSeconds: 30
+
+#containerArgs -- Extra arguments passed to the container as --key=value pair
+containerArgs:
+  kafka-brokers: ""
+  algorithm: sha512
+
+#createKafkaUser -- Should a KafkaUser be created (used with Kafka-Operator)
+createKafkaUser: true
+#kafkaCluster -- What KafkaCluster should the KafkaUser have access too?
+kafkaCluster: production
+
+#createNetworkPolicy -- Should a NetworkPolicy be generated (block all incoming network access except prometheus)
+createNetworkPolicy: true
+
+#ingressFromRule -- Network policy ingress rule (default will block all except a prometheus running in a namespace that has the label name: monitoring)
+ingressFromRule:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+      podSelector:
+        matchLabels:
+          app: prometheus


### PR DESCRIPTION
Enable users to install and setup with helm

The variables file is a bit coded toward use-cases I have in mind but should still be generic enough to work, README have not been updated and can be if it is found necessary.

(It supports creating KafkaUsers using a Kafka-operator)

Regards
Hugo