### PR TITLE
Added option for Kafka API v0.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Use the following ENV vars to change the default options:
 * DEBUG=true or false (default false)
 * ALGORITHM=The SASL algorithm sha256 or sha512 as mechanism (default "")
 * ENABLE_CURRENT_OFFSET=Enable current offset consumer group metric (default false)
+* ENABLE_NEW_PROTOCOL=Enables usage of newer Kafka API calls, which allows to report more accurate metrics. For that option you`ll need Kafka of at least v0.10.2.0
 
 You may also build and run locally using cli arguments.  See the Dockerfile
 for build instructions.

--- a/exporter_client.go
+++ b/exporter_client.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/Shopify/sarama"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+//ExporterClient Main interface for data manipulation
+type ExporterClient interface {
+	kafkaClient() sarama.Client
+	brokers() []*sarama.Broker
+	groups(broker *sarama.Broker) []string
+	updateClusterData() error
+	updateBrokerData(broker *sarama.Broker)
+	reportOffsetMetric(group string, topic string, partition int32, offset float64)
+	reportLagMetric(group string, topic string, partition int32, lag float64)
+}
+
+type exporterClient struct {
+	client sarama.Client
+}
+
+func (e *exporterClient) reportOffsetMetric(group string, topic string, partition int32, offset float64) {
+	CurrentOffset.With(prometheus.Labels{
+		"topic": topic, "group": group,
+		"partition": strconv.FormatInt(int64(partition), 10),
+	}).Set(offset)
+}
+func (e *exporterClient) reportLagMetric(group string, topic string, partition int32, lag float64) {
+	if *enableCurrentOffset {
+		OffsetLag.With(prometheus.Labels{
+			"topic": topic, "group": group,
+			"partition": strconv.FormatInt(int64(partition), 10),
+		}).Set(lag)
+	}
+}
+
+func (e *exporterClient) groups(broker *sarama.Broker) []string {
+	var result []string
+
+	groupsRequest := new(sarama.ListGroupsRequest)
+	groupsResponse, err := broker.ListGroups(groupsRequest)
+
+	if err != nil {
+		log.Printf("Could not list groups: %s\n", err.Error())
+		return result
+	}
+
+	for group, ptype := range groupsResponse.Groups {
+		if *activeOnly && ptype != "consumer" {
+			continue
+		}
+		result = append(result, group)
+	}
+	return result
+}
+
+func (e *exporterClient) brokers() []*sarama.Broker {
+	var result []*sarama.Broker
+
+	for _, broker := range e.client.Brokers() {
+		// Sarama plays russian roulette with the brokers
+		broker.Open(e.client.Config())
+		_, err := broker.Connected()
+		if err != nil {
+			log.Printf("Could not speak to broker %s. Your advertised.listeners may be incorrect.", broker.Addr())
+			continue
+		}
+		result = append(result, broker)
+	}
+	return result
+}
+
+func getConsumerConfig() *sarama.Config {
+	config := sarama.NewConfig()
+	config.ClientID = "kafka-offset-lag-for-prometheus"
+
+	if *saslUser != "" {
+		config.Net.SASL.Enable = true
+		config.Net.SASL.User = *saslUser
+		config.Net.SASL.Password = *saslPass
+	}
+	if *algorithm == "sha512" {
+		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
+		config.Net.SASL.Mechanism = sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA512)
+	} else if *algorithm == "sha256" {
+		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA256} }
+		config.Net.SASL.Mechanism = sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA256)
+	}
+
+	return config
+}

--- a/exporter_client_v1.go
+++ b/exporter_client_v1.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"log"
+	"math"
+	"strings"
+
+	"github.com/Shopify/sarama"
+)
+
+//TopicSet TopicName -> PartitionNumber -> LogEndOffset
+type topicSet map[string]map[int32]int64
+
+type exporterClientV1 struct {
+	exporterClient
+	topicSet topicSet
+}
+
+//NewExporterClientV1 Constructor for original client
+func NewExporterClientV1(brokers []string, kafkaConfig *sarama.Config) (ExporterClient, error) {
+
+	kafkaConfig.Version = sarama.V0_9_0_0
+	client, err := sarama.NewClient(brokers, kafkaConfig)
+
+	result := exporterClientV1{topicSet: nil}
+	result.client = client
+	return &result, err
+}
+
+func (c *exporterClientV1) kafkaClient() sarama.Client {
+	return c.client
+}
+
+func (c *exporterClientV1) updateClusterData() error {
+	c.topicSet = make(topicSet)
+	c.client.RefreshMetadata()
+	// First grab our topics, all partiton IDs, and their offset head
+	topics, err := c.client.Topics()
+	if err != nil {
+		log.Printf("Error fetching topics: %s", err.Error())
+		return err
+	}
+
+	for _, topic := range topics {
+		// Don't include internal topics
+		if strings.HasPrefix(topic, "__") {
+			continue
+		}
+		partitions, err := c.client.Partitions(topic)
+		if err != nil {
+			log.Printf("Error fetching partitions: %s", err.Error())
+			continue
+		}
+		if *debug {
+			log.Printf("Found topic '%s' with %d partitions", topic, len(partitions))
+		}
+		c.topicSet[topic] = make(map[int32]int64)
+		for _, partition := range partitions {
+			toff, err := c.client.GetOffset(topic, partition, sarama.OffsetNewest)
+			if err != nil {
+				log.Printf("Problem fetching offset for topic '%s', partition '%d'", topic, partition)
+				continue
+			}
+			c.topicSet[topic][partition] = toff
+		}
+	}
+	return nil
+}
+
+func (c *exporterClientV1) updateBrokerData(broker *sarama.Broker) {
+	groups := c.groups(broker)
+
+	for _, group := range groups {
+		// This is not very efficient but the kafka API sucks
+		for topic, data := range c.topicSet {
+			offsetsRequest := new(sarama.OffsetFetchRequest)
+			offsetsRequest.Version = 1
+			offsetsRequest.ConsumerGroup = group
+			for partition := range data {
+				offsetsRequest.AddPartition(topic, partition)
+			}
+
+			offsetsResponse, err := broker.FetchOffset(offsetsRequest)
+			if err != nil {
+				log.Printf("Could not get offset: %s\n", err.Error())
+			}
+
+			for _, blocks := range offsetsResponse.Blocks {
+				for partition, block := range blocks {
+					if *debug {
+						log.Printf("Discovered group: %s, topic: %s, partition: %d, offset: %d\n", group, topic, partition, block.Offset)
+					}
+					// Offset will be -1 if the group isn't active on the topic
+					if block.Offset >= 0 {
+						// Because our offset operations aren't atomic we could end up with a negative lag
+						c.reportLagMetric(group, topic, partition, math.Max(float64(data[partition]-block.Offset), 0))
+						c.reportOffsetMetric(group, topic, partition, math.Max(float64(block.Offset), 0))
+					}
+				}
+			}
+		}
+	}
+}
+
+//curl http://localhost:7979/metrics | grep ibul.fluentd.raw
+//kafka-consumer-groups   --bootstrap-server $B_T_ACL   --command-config /home/avrudenko/strp/acl.test.config   --group "ibul.fluentd.raw"   --describe   --verbose
+//"-enable-current-offset"

--- a/exporter_client_v2.go
+++ b/exporter_client_v2.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"log"
+	"math"
+
+	"github.com/Shopify/sarama"
+)
+
+type exporterClientV2 struct {
+	exporterClient
+}
+
+//NewExporterClientV2 Constructor for updated client
+func NewExporterClientV2(brokers []string, kafkaConfig *sarama.Config) (ExporterClient, error) {
+
+	kafkaConfig.Version = sarama.V0_10_2_0
+	client, err := sarama.NewClient(brokers, kafkaConfig)
+
+	result := exporterClientV2{}
+	result.client = client
+	return &result, err
+}
+
+func (c *exporterClientV2) kafkaClient() sarama.Client {
+	return c.client
+}
+
+func (c *exporterClientV2) updateClusterData() error {
+	return c.client.RefreshMetadata()
+}
+
+func (c *exporterClientV2) updateBrokerData(broker *sarama.Broker) {
+	groups := c.groups(broker)
+
+	for _, group := range groups {
+		offsetsRequest := new(sarama.OffsetFetchRequest)
+		offsetsRequest.Version = 2
+		offsetsRequest.ConsumerGroup = group
+
+		offsetsResponse, err := broker.FetchOffset(offsetsRequest)
+		if err != nil {
+			log.Printf("Could not get offset: %s\n", err.Error())
+		}
+
+		for topic, blocks := range offsetsResponse.Blocks {
+
+			for partition, block := range blocks {
+				if *debug {
+					log.Printf("Discovered group: %s, topic: %s, partition: %d, offset: %d\n", group, topic, partition, block.Offset)
+				}
+
+				partitionLatestOffset, err := c.client.GetOffset(topic, partition, sarama.OffsetNewest)
+
+				if err != nil {
+					log.Printf("Failed to obtain Latest Offset for topic: %s, partition: %d", topic, partition)
+				}
+
+				// Because our offset operations aren't atomic we could end up with a negative lag
+				c.reportLagMetric(group, topic, partition, math.Max(float64(partitionLatestOffset-block.Offset), 0))
+				c.reportOffsetMetric(group, topic, partition, math.Max(float64(block.Offset), 0))
+			}
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"flag"
 	"log"
-	"math"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -25,9 +23,8 @@ var (
 	debug               = flag.Bool("debug", false, "Enable debug output.")
 	algorithm           = flag.String("algorithm", "", "The SASL algorithm sha256 or sha512 as mechanism")
 	enableCurrentOffset = flag.Bool("enable-current-offset", false, "Enables metrics for current offset of a consumer group")
+	enableNewProtocol   = flag.Bool("enable-new-protocol", false, "Enables new protocol, which allows to use optimized Kafka API calls. You`ll need Kafka of at least v0.10.2")
 )
-
-type TopicSet map[string]map[int32]int64
 
 func init() {
 	if err := envflag.Parse(); err != nil {
@@ -41,64 +38,26 @@ func init() {
 func main() {
 	go func() {
 		var cycle uint8
-		config := sarama.NewConfig()
-		config.ClientID = "kafka-offset-lag-for-prometheus"
-		config.Version = sarama.V0_9_0_0
-		if *saslUser != "" {
-			config.Net.SASL.Enable = true
-			config.Net.SASL.User = *saslUser
-			config.Net.SASL.Password = *saslPass
+
+		var exporterClient ExporterClient
+		var err error
+
+		if *enableNewProtocol {
+			exporterClient, err = NewExporterClientV2(strings.Split(*kafkaBrokers, ","), getConsumerConfig())
+		} else {
+			exporterClient, err = NewExporterClientV1(strings.Split(*kafkaBrokers, ","), getConsumerConfig())
 		}
-		if *algorithm == "sha512" {
-			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
-			config.Net.SASL.Mechanism = sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA512)
-		} else if *algorithm == "sha256" {
-			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA256} }
-			config.Net.SASL.Mechanism = sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA256)
-		}
-		client, err := sarama.NewClient(strings.Split(*kafkaBrokers, ","), config)
 
 		if err != nil {
 			log.Fatal("Unable to connect to given brokers.")
 		}
 
-		defer client.Close()
+		defer exporterClient.kafkaClient().Close()
 
 		for {
-			topicSet := make(TopicSet)
+
 			time.Sleep(time.Duration(*refreshInt) * time.Second)
 			timer := prometheus.NewTimer(LookupHist)
-			client.RefreshMetadata()
-			// First grab our topics, all partiton IDs, and their offset head
-			topics, err := client.Topics()
-			if err != nil {
-				log.Printf("Error fetching topics: %s", err.Error())
-				continue
-			}
-
-			for _, topic := range topics {
-				// Don't include internal topics
-				if strings.HasPrefix(topic, "__") {
-					continue
-				}
-				partitions, err := client.Partitions(topic)
-				if err != nil {
-					log.Printf("Error fetching partitions: %s", err.Error())
-					continue
-				}
-				if *debug {
-					log.Printf("Found topic '%s' with %d partitions", topic, len(partitions))
-				}
-				topicSet[topic] = make(map[int32]int64)
-				for _, partition := range partitions {
-					toff, err := client.GetOffset(topic, partition, sarama.OffsetNewest)
-					if err != nil {
-						log.Printf("Problem fetching offset for topic '%s', partition '%d'", topic, partition)
-						continue
-					}
-					topicSet[topic][partition] = toff
-				}
-			}
 
 			// Prometheus SDK never TTLs out data points so tmp consumers last
 			// forever. Ugly hack to clean up data points from time to time.
@@ -112,20 +71,13 @@ func main() {
 			var wg sync.WaitGroup
 
 			// Now lookup our group data using the metadata
-			for _, broker := range client.Brokers() {
+			for _, broker := range exporterClient.brokers() {
 				// Sarama plays russian roulette with the brokers
-				broker.Open(client.Config())
-				_, err := broker.Connected()
-				if err != nil {
-					log.Printf("Could not speak to broker %s. Your advertised.listeners may be incorrect.", broker.Addr())
-					continue
-				}
-
 				wg.Add(1)
 
 				go func(broker *sarama.Broker) {
 					defer wg.Done()
-					refreshBroker(broker, topicSet)
+					exporterClient.updateBrokerData(broker)
 				}(broker)
 			}
 
@@ -134,58 +86,4 @@ func main() {
 		}
 	}()
 	prometheusListen(*prometheusAddr)
-}
-
-func refreshBroker(broker *sarama.Broker, topicSet TopicSet) {
-	groupsRequest := new(sarama.ListGroupsRequest)
-	groupsResponse, err := broker.ListGroups(groupsRequest)
-
-	if err != nil {
-		log.Printf("Could not list groups: %s\n", err.Error())
-		return
-	}
-
-	for group, ptype := range groupsResponse.Groups {
-		// do we want to filter by active consumers?
-		if *activeOnly && ptype != "consumer" {
-			continue
-		}
-		// This is not very efficient but the kafka API sucks
-		for topic, data := range topicSet {
-			offsetsRequest := new(sarama.OffsetFetchRequest)
-			offsetsRequest.Version = 1
-			offsetsRequest.ConsumerGroup = group
-			for partition := range data {
-				offsetsRequest.AddPartition(topic, partition)
-			}
-
-			offsetsResponse, err := broker.FetchOffset(offsetsRequest)
-			if err != nil {
-				log.Printf("Could not get offset: %s\n", err.Error())
-			}
-
-			for _, blocks := range offsetsResponse.Blocks {
-				for partition, block := range blocks {
-					if *debug {
-						log.Printf("Discovered group: %s, topic: %s, partition: %d, offset: %d\n", group, topic, partition, block.Offset)
-					}
-					// Offset will be -1 if the group isn't active on the topic
-					if block.Offset >= 0 {
-						// Because our offset operations aren't atomic we could end up with a negative lag
-						lag := math.Max(float64(data[partition]-block.Offset), 0)
-						OffsetLag.With(prometheus.Labels{
-							"topic": topic, "group": group,
-							"partition": strconv.FormatInt(int64(partition), 10),
-						}).Set(lag)
-						if *enableCurrentOffset {
-							CurrentOffset.With(prometheus.Labels{
-								"topic": topic, "group": group,
-								"partition": strconv.FormatInt(int64(partition), 10),
-							}).Set(math.Max(float64(block.Offset), 0))
-						}
-					}
-				}
-			}
-		}
-	}
 }


### PR DESCRIPTION
We experienced a lot of problems with a long delay between offsets commit to kafka and lag report from metric.
Our Kafka cluster contains of ~10k partitions and ~200 consumer groups.
Lower REFRESH_INTERVAL didn`t solve the case.
New Kafka API solved the issue by providing optimized algorithm for offset access.
It could be enabled with flag -enable-new-protocol.

For backward compatibility default client uses Kafka API v0.9