### PR TITLE
use multi-stage docker build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM golang:1.13
 LABEL maintainer "https://hub.docker.com/u/pceric/"
 WORKDIR /go/src/kafka-offset-lag-for-prometheus
-RUN useradd -ms /bin/sh kafkaoffsetlag
-COPY . .
-RUN go get -u "github.com/Shopify/sarama" \
+RUN go get -v -u "github.com/Shopify/sarama" \
               "github.com/kouhin/envflag" \
               "github.com/prometheus/client_golang/prometheus" \
               "github.com/prometheus/client_golang/prometheus/promhttp" \
               "github.com/xdg/scram"
-RUN go install
-USER kafkaoffsetlag
-ENTRYPOINT ["/go/bin/kafka-offset-lag-for-prometheus"]
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o app
+
+FROM scratch
+COPY --from=0 /go/src/kafka-offset-lag-for-prometheus/app /kafka-offset-lag-for-prometheus
+USER 1000
+ENTRYPOINT ["/kafka-offset-lag-for-prometheus"]


### PR DESCRIPTION
By using a multi-stage Docker build with a scratch base the image size is reduced from 1.2GB down to 12MB.