### PR TITLE
bump new API config.Version to V1_0_0_0 to fix SASL handshake

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 		config.ClientID = "kafka-offset-lag-for-prometheus"
 		config.Version = sarama.V0_9_0_0
 		if *enableNewAPI {
-			config.Version = sarama.V0_10_2_0
+			config.Version = sarama.V1_0_0_0
 		}
 		if *saslUser != "" {
 			config.Net.SASL.Enable = true


### PR DESCRIPTION
This commit in samsara (https://github.com/IBM/sarama/commit/765bfa3ae935e3a8ec36b8776ee5d3308b40f28a) which first appears in samsara [v1.41.0](https://github.com/IBM/sarama/releases/tag/v1.41.0) bumps the default version to `SASLHandshakeV1` in `Net.SASL.NewConfig()`.

This leads to a failure of "Error while performing SASL handshake <hostname>" when using SASL auth.  The failure happens immediately after the socket connection is established and prior to any handshake occurring.  This is the code path that leads to the failure:
* https://github.com/IBM/sarama/blob/d0bd279e8a7c9d759258d5092bda2b53dac3571e/broker.go#L260
  * calls `authenticateViaSASLv1()` now whereas it would have called `authenticateViaSASLv0()` before the upstream commit
* https://github.com/IBM/sarama/blob/d0bd279e8a7c9d759258d5092bda2b53dac3571e/broker.go#L998
  * runs `if !b.conf.Version.IsAtLeast(rb.requiredVersion())` to check that the configured `config.Version` is at least enough to allow the SASLv1 handshake message
* https://github.com/IBM/sarama/blob/d0bd279e8a7c9d759258d5092bda2b53dac3571e/sasl_handshake_request.go#L40
  * `SaslHandshakeRequest` requires a minimum version of `1_0_0_0` for a Version 1 handshake message.
  * This minimum version was *previously* `0_10_0_0` prior to the upstream commit

The default `config.Version` in `main.go` is currently  `V0_9_0_0` which is too low for the SASL handshake (even before the upstream commit).  The `config.Version` used when `enable-new-api` is specified is currently `V0_10_2_0` which is also too low for the SASL handshake given the new upstream commit.

I was able to successfully auth using SASL/PLAIN over TLS using `enable-new-api` and this diff.